### PR TITLE
Updated install instructions for case-sensitive operation systems

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -3,7 +3,18 @@ Symfony2 bundle for [Postmark](http://postmarkapp.com) API
 ## Using submodules
 
         git submodule add https://github.com/miguel250/PostmarkBundle.git vendor/bundles/Postmarkapp/PostmarkBundle
-        git submodule add https://github.com/miguel250/postmark-php.git  vendor/postmark
+        git submodule add https://github.com/miguel250/postmark-php.git  vendor/Postmark
+
+## Using deps file
+```
+[postmark]
+    git=git://github.com/miguel250/postmark-php.git
+    target=/Postmark
+
+[PostmarkBundle]
+    git=git://github.com/digitalpioneers/PostmarkBundle.git
+    target=/bundles/Postmarkapp/PostmarkBundle
+```
 
 Add PostmarkBundle to your application kernel
 -----

--- a/Services/Postmark.php
+++ b/Services/Postmark.php
@@ -11,7 +11,7 @@
 
 namespace Postmarkapp\PostmarkBundle\Services;
 
-use Postmark\Postmark as PostmarkClass;
+use \Postmark\Postmark as PostmarkClass;
 
 /**
  * Service for postmark api


### PR DESCRIPTION
Hey there,

This is almost a documentation fix, when the sf2 namespace registering in the autoload file points to vendor dir, the folder has to be uppercase because of psr-0 standard. This is also very important for case-sensitive operation systems.
