### PR TITLE
Fixed issue with sending multiple e-mails

### DIFF
--- a/Postmark/Message.php
+++ b/Postmark/Message.php
@@ -298,7 +298,7 @@ class Message
             unset($this->tag);
         }
 
-        if (sizeof($this->attachments) > 0) {
+        if (!empty($this->attachments) && sizeof($this->attachments) > 0) {
         	$data['attachments'] = array();
 
         	foreach($this->attachments as $file) {

--- a/Tests/Postmark/MessageTest.php
+++ b/Tests/Postmark/MessageTest.php
@@ -41,4 +41,34 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($response['ErrorCode'], 0);
         $this->assertEquals($response['Message'], 'Test job accepted');
     }
+
+    /**
+     * Test multiple send requests
+     *
+     * @covers  MZ\PostmarkBundle\Postmark\Message::Send
+     */
+    public function testSendMultipleMessages()
+    {
+    	$client = new HTTPClient('POSTMARK_API_TEST');
+    	$message = new Message($client, 'test@test.com', 'multiple test one');
+    	$message->addTo('test2@test.com', 'Test Test');
+    	$message->setSubject('subject');
+    	$message->setHTMLMessage('<b>email body</b>');
+    	$message->addAttachment(new File(__FILE__));
+    	$response = json_decode($message->send(), true);
+
+    	$this->assertEquals($response['To'], 'Test Test <test2@test.com>');
+    	$this->assertEquals($response['ErrorCode'], 0);
+    	$this->assertEquals($response['Message'], 'Test job accepted');
+
+    	// Added second test, without attachment
+    	$message->addTo('test3@test.com', 'Test Test');
+    	$message->setSubject('subject second e-mail');
+    	$message->setHTMLMessage('<b>second email body</b>');
+    	$response = json_decode($message->send(), true);
+
+    	$this->assertEquals($response['To'], 'Test Test <test3@test.com>');
+    	$this->assertEquals($response['ErrorCode'], 0);
+    	$this->assertEquals($response['Message'], 'Test job accepted');
+    }
 }


### PR DESCRIPTION
We found an issue with sending multiple e-mails at once in the patch I submitted a couple of days ago. I added a test to confirm the bug and fixed the issue.

Let me know if you need anything changed before you can pull this in!
