### PR TITLE
Some attachment improvements

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -35,7 +35,10 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('use_ssl')
                     ->defaultTrue()
-                    ->end()
+                ->end()
+                ->scalarNode('timeout')
+                    ->defaultValue(5)
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/MZPostmarkExtension.php
+++ b/DependencyInjection/MZPostmarkExtension.php
@@ -25,7 +25,7 @@ class MZPostmarkExtension extends Extension
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
-        foreach (array('api_key', 'from_email', 'from_name', 'use_ssl') as $attribute) {
+        foreach (array('api_key', 'from_email', 'from_name', 'use_ssl', 'timeout') as $attribute) {
             if (isset($config[$attribute])) {
                 $container->setParameter('mz_postmark.'.$attribute, $config[$attribute]);
             }

--- a/Postmark/HTTPClient.php
+++ b/Postmark/HTTPClient.php
@@ -42,10 +42,9 @@ class HTTPClient
      */
     public function __construct($apiKey)
     {
-        $this->apiKey = $apiKey;
-        $this->httpHeaders['Accept'] = 'application/json';
-        $this->httpHeaders['Content-Type'] = 'application/json';
-        $this->httpHeaders['X-Postmark-Server-Token'] =  $this->apiKey;
+        $this->setApiKey($apiKey);
+        $this->setHTTPHeader('Accept', 'application/json');
+        $this->setHTTPHeader('Content-Type', 'application/json');
     }
 
     /**
@@ -56,6 +55,7 @@ class HTTPClient
     public function setApiKey($key)
     {
         $this->apiKey = $key;
+        $this->setHTTPHeader('X-Postmark-Server-Token', $this->apiKey);
     }
 
     /**

--- a/Postmark/HTTPClient.php
+++ b/Postmark/HTTPClient.php
@@ -36,13 +36,22 @@ class HTTPClient
     protected $apiKey;
 
     /**
+     * Postmark timeout in seconds
+     *
+     * @var int
+     */
+    protected $timeout;
+
+    /**
      * Constructor
      *
      * @param string $apiKey
+     * @param int $timeout
      */
-    public function __construct($apiKey)
+    public function __construct($apiKey, $timeout = 5)
     {
         $this->setApiKey($apiKey);
+        $this->setTimeout($timeout);
         $this->setHTTPHeader('Accept', 'application/json');
         $this->setHTTPHeader('Content-Type', 'application/json');
     }
@@ -56,6 +65,16 @@ class HTTPClient
     {
         $this->apiKey = $key;
         $this->setHTTPHeader('X-Postmark-Server-Token', $this->apiKey);
+    }
+
+    /**
+     * Set Postmark timeout in seconds
+     *
+     * @param int $timeout
+     */
+    public function setTimeout($timeout)
+    {
+        $this->timeout = $timeout;
     }
 
     /**
@@ -78,6 +97,7 @@ class HTTPClient
     public function sendRequest($url, $data)
     {
         $curl = new Curl();
+        $curl->setTimeout($this->timeout);
         $browser = new Browser($curl);
         $response = $browser->post($url, $this->httpHeaders, $data);
 

--- a/Postmark/Message.php
+++ b/Postmark/Message.php
@@ -102,14 +102,14 @@ class Message
      * @var string
      */
     private $textMessage;
-    
+
     /**
      * Indicates wheter service should SSL or not
-     * 
+     *
      * @var boolean
      */
      private $useSsl;
-    
+
     /**
      * Constructor
      *
@@ -207,11 +207,25 @@ class Message
     /**
      * Add attachment
      *
-     * @param array $attachment
+     * @param File $file
+     * @param string $filename  null
+     * @param string $mimeType  nill
      */
-    public function addAttachment($attachment)
+    public function addAttachment(File $file, $filename = null, $mimeType = null)
     {
-    	$this->attachments[] = $attachment;
+        if (empty($filename)) {
+            $filename = $file->getFilename();
+        }
+
+        if (empty($mimeType)) {
+            $mimeType = $file->getMimeType();
+        }
+
+    	$this->attachments[] = array(
+                    'Name' => $filename,
+                    'Content' => base64_encode(file_get_contents($file->getRealPath())),
+                    'ContentType' => $mimeType
+                );
     }
 
     /**
@@ -243,7 +257,7 @@ class Message
     {
         $this->textMessage = $textMessage;
     }
-    
+
      /**
      * Set Use ssl
      *
@@ -316,18 +330,8 @@ class Message
             unset($this->tag);
         }
 
-        if (!empty($this->attachments) && sizeof($this->attachments) > 0) {
-        	$data['attachments'] = array();
-
-        	foreach($this->attachments as $file) {
-        		$attachment = array(
-        			'Name' => $file->getFilename(),
-        			'Content' => base64_encode(file_get_contents($file->getRealPath())),
-        			'ContentType' => $file->getMimeType()
-        		);
-        		$data['attachments'][] = $attachment;
-        	}
-
+        if (!empty($this->attachments)) {
+        	$data['Attachments'] = $this->attachments;
         	unset($this->attachments);
         }
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ mz_postmark:
     api_key: API KEY
     from_email: info@my-app.com
     from_name: My App, Inc
-	use_ssl: true
+    use_ssl: true
+    timeout: 5
 ```
 
 ## Usage
@@ -67,11 +68,12 @@ mz_postmark:
   $message->addTo('test@gmail.com', 'Test Test');
   $message->setSubject('subject');
   $message->setHTMLMessage('<b>email body</b>');
+  $message->addAttachment(new Symfony\Component\HttpFoundation\File\File(__FILE__));
   $message->send()
 
   $message->addTo('test2@gmail.com', 'Test2 Test');
   $message->setSubject('subject2');
   $message->setHTMLMessage('<b>email body</b>');
-  $message->addAttachment(new Symfony\Component\HttpFoundation\File\File(__FILE__));
+  $message->addAttachment(new Symfony\Component\HttpFoundation\File\File(__FILE__), 'usethisfilename.php', 'text/plain');
   $message->send()
 ```

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -10,6 +10,7 @@
         <parameter key="mz_postmark.from_email" />
         <parameter key="mz_postmark.from_name" />
         <parameter key="mz_postmark.use_ssl" />
+        <parameter key="mz_postmark.timeout" />
         <parameter key="mz_postmark.postmark.client.class">MZ\PostmarkBundle\Postmark\HTTPClient</parameter>
         <parameter key="mz_postmark.postmark.message.class">MZ\PostmarkBundle\Postmark\Message</parameter>
     </parameters>
@@ -17,6 +18,7 @@
     <services>
         <service id="postmark.client" class="%mz_postmark.postmark.client.class%">
             <argument>%mz_postmark.api_key%</argument>
+            <argument>%mz_postmark.timeout%</argument>
         </service>
 
         <service id="postmark.message" class="%mz_postmark.postmark.message.class%">

--- a/Tests/Postmark/MessageTest.php
+++ b/Tests/Postmark/MessageTest.php
@@ -31,13 +31,13 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     {
         $client = new HTTPClient('POSTMARK_API_TEST');
         $message = new Message($client, 'test@test.com', 'test name');
-        $message->addTo('test2@test.com', 'Test Test');
+        $message->addTo('test1@test.com', 'Test Test');
         $message->setSubject('subject');
         $message->setHTMLMessage('<b>email body</b>');
-        $message->addAttachment(new File(__FILE__));
+        $message->addAttachment(new File(__FILE__), 'attachment.php', 'text/plain'); // Attachment with custom filename and mimetype
         $response = json_decode($message->send(), true);
 
-        $this->assertEquals($response['To'], 'Test Test <test2@test.com>');
+        $this->assertEquals($response['To'], 'Test Test <test1@test.com>');
         $this->assertEquals($response['ErrorCode'], 0);
         $this->assertEquals($response['Message'], 'Test job accepted');
     }
@@ -54,21 +54,32 @@ class MessageTest extends \PHPUnit_Framework_TestCase
     	$message->addTo('test2@test.com', 'Test Test');
     	$message->setSubject('subject');
     	$message->setHTMLMessage('<b>email body</b>');
-    	$message->addAttachment(new File(__FILE__));
+    	$message->addAttachment(new File(__FILE__), 'attachment.php'); // Attachment with custom filename
     	$response = json_decode($message->send(), true);
 
     	$this->assertEquals($response['To'], 'Test Test <test2@test.com>');
     	$this->assertEquals($response['ErrorCode'], 0);
     	$this->assertEquals($response['Message'], 'Test job accepted');
 
-    	// Added second test, without attachment
+    	// Send a second message
     	$message->addTo('test3@test.com', 'Test Test');
     	$message->setSubject('subject second e-mail');
     	$message->setHTMLMessage('<b>second email body</b>');
+        $message->addAttachment(new File(__FILE__), 'attachment.php'); // Attachment without custom filename or mimetype
     	$response = json_decode($message->send(), true);
 
     	$this->assertEquals($response['To'], 'Test Test <test3@test.com>');
     	$this->assertEquals($response['ErrorCode'], 0);
     	$this->assertEquals($response['Message'], 'Test job accepted');
+
+        // Send a third message, without attachment
+        $message->addTo('test4@test.com', 'Test Test');
+        $message->setSubject('subject second e-mail');
+        $message->setHTMLMessage('<b>second email body</b>');
+        $response = json_decode($message->send(), true);
+
+        $this->assertEquals($response['To'], 'Test Test <test4@test.com>');
+        $this->assertEquals($response['ErrorCode'], 0);
+        $this->assertEquals($response['Message'], 'Test job accepted');
     }
 }


### PR DESCRIPTION
This pull request contains:
- Possibility to set custom filename/mimetype for attachments (Issue #15)
- Config parameter for the timeout (Issue #16)
- Fix that setApiKey in HTTPClient actually updates the HTTP header

Also added tests for the attachment changes and everything is backwards compatible.

Hope you can pull this in!
