### PR TITLE
Added chunked sending for 500+ messages

### DIFF
--- a/Postmark/Message.php
+++ b/Postmark/Message.php
@@ -382,22 +382,29 @@ class Message
     /**
      * Make request to postmark api
      *
-     * @return string
+     * @return string|array
      */
     public function send()
     {
         $this->queue();
 
-        if (count($this->queue) === 1) {
-            $payload = json_encode($this->queue[0]);
-            $path = 'email';
-        } else {
-            $payload = json_encode($this->queue);
-            $path = 'email/batch';
+        $responses = array();
+        $chunks = array_chunk($this->queue, 500);
+
+        foreach ($chunks as $chunk)
+        {
+            if (count($this->queue) === 1) {
+                $payload = json_encode($this->queue[0]);
+                $path = 'email';
+            } else {
+                $payload = json_encode($this->queue);
+                $path = 'email/batch';
+            }
+
+            $responses[] = $this->client->sendRequest($path, $payload);
         }
 
         $this->queue = array();
-
-        return $this->client->sendRequest($path, $payload);
+        return (count($responses) == 1) ? $responses[0] : $responses;
     }
 }

--- a/Postmark/Message.php
+++ b/Postmark/Message.php
@@ -397,14 +397,15 @@ class Message
                 $payload = json_encode($this->queue[0]);
                 $path = 'email';
             } else {
-                $payload = json_encode($this->queue);
+                $payload = json_encode($chunk);
                 $path = 'email/batch';
             }
 
             $responses[] = $this->client->sendRequest($path, $payload);
         }
 
+        $responses = (count($this->queue) === 1) ? $responses[0] : $responses;
         $this->queue = array();
-        return (count($responses) == 1) ? $responses[0] : $responses;
+        return $responses;
     }
 }

--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ $message->addTo('test@gmail.com', 'Test Test');
 $message->setSubject('subject');
 $message->setHTMLMessage('<b>email body</b>');
 $message->addAttachment(new Symfony\Component\HttpFoundation\File\File(__FILE__));
-$message->send();
+$response = $message->send();
 
 $message->addTo('test2@gmail.com', 'Test2 Test');
 $message->setSubject('subject2');
 $message->setHTMLMessage('<b>email body</b>');
 $message->addAttachment(new Symfony\Component\HttpFoundation\File\File(__FILE__), 'usethisfilename.php', 'text/plain');
-$message->send();
+$response = $message->send();
 ?>
 ```
 
@@ -91,6 +91,6 @@ $message->queue(); // Queue the message instead of sending it directly
 $message->addTo('test2@gmail.com', 'Test2 Test');
 $message->setSubject('subject2');
 $message->setHTMLMessage('<b>email body</b>');
-$message->send(); // Send both messages
+$responses = $message->send(); // Send both messages, note that you'll get an array of json responses instead of just the json response
 ?>
 ```

--- a/Tests/Postmark/MessageTest.php
+++ b/Tests/Postmark/MessageTest.php
@@ -146,9 +146,8 @@ class MessageTest extends \PHPUnit_Framework_TestCase
             $message->queue();
             $count++;
         }
-        
-        $response = json_decode($message->send(), true);
-        $this->assertEquals(410, $response['ErrorCode']);
-        $this->assertEquals('You may only send up to 500 messages in a single batched request.', $response['Message']);
+
+        $responses = $message->send();
+        $this->assertEquals(2, count($responses));
     }
 }

--- a/Tests/Postmark/MessageTest.php
+++ b/Tests/Postmark/MessageTest.php
@@ -111,7 +111,9 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $message->setHTMLMessage('<b>second email body</b>');
 
         // Send the queue
-        $response = json_decode($message->send(), true);
+        $responses = $message->send();
+        $this->assertEquals(1, count($responses));
+        $response = json_decode($responses[0], true);
 
         $this->assertEquals('Test Test <test2@test.com>', $response[0]['To']);
         $this->assertEquals(0, $response[0]['ErrorCode']);


### PR DESCRIPTION
Sending 500+ messages at once now creates chunks so Postmark won't complain. This fixes issue #20. The only downside is the response changes to an array above 500 messages, I think this could be confusing. Should we change all responses to arrays or should the 500+ messages response be converted to some kind of string? What do you think would be right withou confusing too much users?
