### PR TITLE
Properly escape quotes in setFrom, addTo etc.

### DIFF
--- a/Postmark/Message.php
+++ b/Postmark/Message.php
@@ -133,7 +133,10 @@ class Message
     public function setFrom($email, $name = null)
     {
         if (!empty($name)) {
-            $email = "{$name} <{$email}>";
+            $email = sprintf('"%s" <%s>',
+                str_replace('"', '', $name),
+                $email
+            );
         }
 
         $this->from = $email;
@@ -151,7 +154,10 @@ class Message
     public function addTo($email, $name = null)
     {
         if (!empty($name)) {
-            $email = "{$name} <{$email}>";
+            $email = sprintf('"%s" <%s>',
+                str_replace('"', '', $name),
+                $email
+            );
         }
 
         $this->to[] = $email;
@@ -169,7 +175,10 @@ class Message
     public function addCC($email, $name = null)
     {
         if (!empty($name)) {
-            $email = "{$name} <{$email}>";
+            $email = sprintf('"%s" <%s>',
+                str_replace('"', '', $name),
+                $email
+            );
         }
 
         $this->cc[] = $email;
@@ -187,7 +196,10 @@ class Message
     public function addBCC($email, $name = null)
     {
         if (!empty($name)) {
-            $email = "{$name} <{$email}>";
+            $email = sprintf('"%s" <%s>',
+                str_replace('"', '', $name),
+                $email
+            );
         }
 
         $this->bcc[] = $email;
@@ -205,7 +217,10 @@ class Message
     public function setReplyTo($email, $name = null)
     {
         if (!empty($name)) {
-            $email = "{$name} <{$email}>";
+            $email = sprintf('"%s" <%s>',
+                str_replace('"', '', $name),
+                $email
+            );
         }
 
         $this->replyTo = $email;

--- a/Tests/Postmark/MessageTest.php
+++ b/Tests/Postmark/MessageTest.php
@@ -37,7 +37,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $message->addAttachment(new File(__FILE__), 'attachment.php', 'text/plain'); // Attachment with custom filename and mimetype
         $response = json_decode($message->send(), true);
 
-        $this->assertEquals('Test Test <test1@test.com>', $response['To']);
+        $this->assertEquals('"Test Test" <test1@test.com>', $response['To']);
         $this->assertEquals(0, $response['ErrorCode']);
         $this->assertEquals('Test job accepted', $response['Message']);
     }
@@ -57,7 +57,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $message->addAttachment(new File(__FILE__), 'attachment.php'); // Attachment with custom filename
         $response = json_decode($message->send(), true);
 
-        $this->assertEquals('Test Test <test2@test.com>', $response['To']);
+        $this->assertEquals('"Test Test" <test2@test.com>', $response['To']);
         $this->assertEquals(0, $response['ErrorCode']);
         $this->assertEquals('Test job accepted', $response['Message']);
 
@@ -68,7 +68,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $message->addAttachment(new File(__FILE__), 'attachment.php'); // Attachment without custom filename or mimetype
         $response = json_decode($message->send(), true);
 
-        $this->assertEquals('Test Test <test3@test.com>', $response['To']);
+        $this->assertEquals('"Test Test" <test3@test.com>', $response['To']);
         $this->assertEquals(0, $response['ErrorCode']);
         $this->assertEquals('Test job accepted', $response['Message']);
 
@@ -78,7 +78,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $message->setHTMLMessage('<b>second email body</b>');
         $response = json_decode($message->send(), true);
 
-        $this->assertEquals('Test Test <test4@test.com>', $response['To']);
+        $this->assertEquals('"Test Test" <test4@test.com>', $response['To']);
         $this->assertEquals(0, $response['ErrorCode']);
         $this->assertEquals('Test job accepted', $response['Message']);
     }
@@ -115,15 +115,15 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($responses));
         $response = json_decode($responses[0], true);
 
-        $this->assertEquals('Test Test <test2@test.com>', $response[0]['To']);
+        $this->assertEquals('"Test Test" <test2@test.com>', $response[0]['To']);
         $this->assertEquals(0, $response[0]['ErrorCode']);
         $this->assertEquals('Test job accepted', $response[0]['Message']);
 
-        $this->assertEquals('Test Test <test3@test.com>', $response[1]['To']);
+        $this->assertEquals('"Test Test" <test3@test.com>', $response[1]['To']);
         $this->assertEquals(0, $response[1]['ErrorCode']);
         $this->assertEquals('Test job accepted', $response[1]['Message']);
 
-        $this->assertEquals('Test Test <test4@test.com>', $response[2]['To']);
+        $this->assertEquals('"Test Test" <test4@test.com>', $response[2]['To']);
         $this->assertEquals(0, $response[2]['ErrorCode']);
         $this->assertEquals('Test job accepted', $response[2]['Message']);
     }


### PR DESCRIPTION
Put the name inside quotes to support comma's. 

Postmark does not support escaped quotes like this: `"Company name \"test\" <info@example.org>"` so we strip them.
